### PR TITLE
Uses develop branch of jubatus_core in TravisCI if in develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,19 @@ install:
       docker exec test apt-get --force-yes -y install jubatus python-dev python-pip g++;
     fi
   - docker exec test pip install jubatus cython
+  - if [ "$TRAVIS_BRANCH" != "master" ]; then
+      if [ "$DIST" == "centos" ]; then
+        docker exec test yum -y install git;
+      elif [ "$DIST" == "ubuntu" ]; then
+        docker exec test apt-get --force-yes -y install git bzip2 libmsgpack-dev;
+      fi;
+      docker exec test git clone -b develop https://github.com/jubatus/jubatus_core.git;
+      if [ "$DIST" == "centos" ]; then
+        docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/usr --regexp-library=none && ./waf build && ./waf install";
+      elif [ "$DIST" == "ubuntu" ]; then
+        docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/opt/jubatus --regexp-library=none && ./waf build && ./waf install";
+      fi
+    fi
 
 script:
   - if [ "$DIST" == "centos" ]; then


### PR DESCRIPTION
今まではTravisCIの環境構築にjubatus/jubatus_coreのバイナリパッケージを使っていましたが
https://github.com/jubatus/jubatus_core/issues/319
の様なインタフェースの変更が合った場合，jubatus_coreがリリースされるまで追従できないため，
embedded-jubatus-pythonのmasterブランチ以外(develop)を使っているときは，
jubatus_coreのdevelop版をcloneして上書きインストールするようにしました