### PR TITLE
Add pickle support for Py3

### DIFF
--- a/src/embedded_jubatus.pyx
+++ b/src/embedded_jubatus.pyx
@@ -113,6 +113,15 @@ class _JubatusBase(object):
     def get_client(self):
         raise RuntimeError
 
+    def __getstate__(self):
+        return (self.get_config(), self.save_bytes())
+
+    def __setstate__(self, state):
+        import json
+        cfg, model = state
+        self.__init__(json.loads(cfg))
+        self.load_bytes(model)
+
 include 'types.pyx'
 include 'anomaly.pyx'
 include 'bandit.pyx'

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,7 +1,9 @@
 import json
 import os
+import pickle
 import tempfile
 import unittest
+import sys
 
 try:
     from unittest import skipIf
@@ -88,6 +90,11 @@ class TestClassifier(unittest.TestCase):
         x.load_bytes(model)
         _test_classify(x)
         self.assertEqual(CONFIG, json.loads(x.get_config()))
+
+        if sys.version_info[0] == 3:
+            x = pickle.loads(pickle.dumps(x))
+            _test_classify(x)
+            self.assertEqual(CONFIG, json.loads(x.get_config()))
 
     def test_str(self):
         x = Classifier(CONFIG)


### PR DESCRIPTION
Classifier等のインスタンスのpickel化に対応させます (Python3環境のみ)

scikit-learnのGridSearchCV等を利用する際に，pickle化が必須となっているため，
このパッチにより，scikit-learnとの連携が少し楽になるはずです