### PR TITLE
fix API behaviors to comply with RPC version

### DIFF
--- a/src/embedded_jubatus.pyx
+++ b/src/embedded_jubatus.pyx
@@ -69,7 +69,7 @@ class _JubatusBase(object):
         else:
             config = json.dumps(config, sort_keys=True, indent=4)
         (self.get_config, self.save_bytes, self.load_bytes,
-         self.clear, typ) = self._init(config.encode('utf8'))
+         self._clear_impl, typ) = self._init(config.encode('utf8'))
         if str != bytes and isinstance(typ, bytes):
             typ = typ.decode('ascii')
         self._type = typ
@@ -78,22 +78,23 @@ class _JubatusBase(object):
         host, port = '127.0.0.1', 0
         path = '/tmp/{host}_{port}_{type}_{id}.jubatus'.format(
             host=host, port=port, type=self._type, id=id_)
-        return (path, {host: port})
+        return (path, '{host}_{port}'.format(host=host, port=port))
+
+    def clear(self):
+        self._clear_impl()
+        return True
 
     def load(self, id_):
-        path, ret = self._get_model_path(id_)
-        try:
-            with open(path, 'rb') as f:
-                self.load_bytes(f.read())
-            return True
-        except Exception:
-            return False
+        path, name = self._get_model_path(id_)
+        with open(path, 'rb') as f:
+            self.load_bytes(f.read())
+        return True
 
     def save(self, id_):
-        path, ret = self._get_model_path(id_)
+        path, name = self._get_model_path(id_)
         with open(path, 'wb') as f:
             f.write(self.save_bytes())
-        return ret
+        return {name: path}
 
     def get_status(self):
         raise RuntimeError

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -78,7 +78,7 @@ class TestClassifier(unittest.TestCase):
         _test_classify(x)
         model = x.save_bytes()
 
-        x.clear()
+        self.assertTrue(x.clear())
         self.assertEqual({}, x.get_labels())
         x.set_label('Y')
         x.set_label('N')
@@ -139,7 +139,7 @@ class TestClassifier(unittest.TestCase):
 
         _remove_model()
         try:
-            self.assertEqual({'127.0.0.1': 0}, x.save('hoge'))
+            self.assertEqual({'127.0.0.1_0': '/tmp/127.0.0.1_0_classifier_hoge.jubatus'}, x.save('hoge'))
             self.assertTrue(os.path.isfile(path))
             x = Classifier(CONFIG)
             self.assertTrue(x.load('hoge'))


### PR DESCRIPTION
This PR fixes embedded API behave the same way as RPC API.

* `clear` must always return True, instead of `None`.
* `save` must return map of server identifier to saved file path, instead of map of host to port.
* `load` must raise exception when failed to load model, instead of returning False.