### PR TITLE
deprecate Ubuntu12.04 and fix travis-ci on CentOS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,22 +43,31 @@ before_install:
 install:
   - if [ "$DIST" == "centos" ]; then
       docker exec test yum -y install gcc-c++ python-devel epel-release;
+      if [ $VERSION -eq 6 ]; then
+        docker exec test yum -y install centos-release-scl-rh;
+        docker exec test yum -y install python27 python27-python-pip;
+        docker exec test /usr/bin/scl enable python27 --pip install --upgrade pip setuptools;
+      else
+        docker exec test yum -y install python-pip;
+        docker exec test pip install --upgrade pip;
+      fi;
       if [ "$TRAVIS_BRANCH" == "master" ]; then
         docker exec test yum -y install jubatus-core-devel;
-      fi;
-      docker exec test yum -y install python-pip;
-      if [ $VERSION -eq 6 ]; then
-        docker exec test pip install --upgrade setuptools;
       fi;
     fi
   - if [ "$DIST" == "ubuntu" ]; then
       docker exec test apt-get -y update;
       docker exec test apt-get --force-yes -y install python-dev python-pip g++;
+      docker exec test pip install --upgrade pip;
       if [ "$TRAVIS_BRANCH" == "master" ]; then
         docker exec test apt-get --force-yes -y install jubatus;
       fi;
     fi
-  - docker exec test pip install jubatus cython
+  - if [ "$DIST" == "centos" ] && [ $VERSION -eq 6 ]; then
+      docker exec test /usr/bin/scl enable python27 -- pip install jubatus cython numpy scipy;
+    else
+      docker exec test pip install jubatus cython numpy scipy;
+    fi
   - if [ "$TRAVIS_BRANCH" != "master" ]; then
       if [ "$DIST" == "centos" ]; then
         docker exec test yum -y install git bzip2 msgpack-devel-0.5.9;
@@ -75,18 +84,21 @@ install:
 
 script:
   - if [ "$DIST" == "centos" ]; then
-      docker exec -t test bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      if [ $VERSION -eq 6 ]; then
+        docker exec -t test /usr/bin/scl enable python27 -- bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      else
+        docker exec -t test bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      fi;
     elif [ "$DIST" == "ubuntu" ]; then
       docker exec -t test bash -ic "source /opt/jubatus/profile; python ./setup.py build_ext -i && python ./setup.py test";
     fi
-  - if [ "$DIST" == "centos" ]; then
-      docker exec test yum -y install numpy scipy;
-    elif [ "$DIST" == "ubuntu" ]; then
-      docker exec test apt-get --force-yes -y install python-numpy python-scipy;
-    fi
   - docker exec test rm -rf build
   - if [ "$DIST" == "centos" ]; then
-      docker exec -t test bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      if [ $VERSION -eq 6 ]; then
+        docker exec -t test /usr/bin/scl enable python27 -- bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      else
+        docker exec -t test bash -ic "python ./setup.py build_ext -i && python ./setup.py test";
+      fi;
     elif [ "$DIST" == "ubuntu" ]; then
       docker exec -t test bash -ic "source /opt/jubatus/profile; python ./setup.py build_ext -i && python ./setup.py test";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
       - VERSION=7
     - env:
       - DIST=ubuntu
-      - VERSION=12.04
-    - env:
-      - DIST=ubuntu
       - VERSION=14.04
     - env:
       - DIST=ubuntu
@@ -36,9 +33,7 @@ before_install:
         docker exec test rpm -Uvh http://download.jubat.us/yum/rhel/7/stable/x86_64/jubatus-release-7-2.el7.x86_64.rpm;
       fi;
     elif [ "$DIST" == "ubuntu" ]; then
-      if [ "$VERSION" == "12.04" ]; then
-        docker exec test sh -c "echo 'deb http://download.jubat.us/apt/ubuntu/precise binary/' > /etc/apt/sources.list.d/jubatus.list";
-      elif [ "$VERSION" == "14.04" ]; then
+      if [ "$VERSION" == "14.04" ]; then
         docker exec test sh -c "echo 'deb http://download.jubat.us/apt/ubuntu/trusty binary/' >  /etc/apt/sources.list.d/jubatus.list";
       elif [ "$VERSION" == "16.04" ]; then
         docker exec test sh -c "echo 'deb http://download.jubat.us/apt/ubuntu/xenial binary/' >  /etc/apt/sources.list.d/jubatus.list";
@@ -75,7 +70,7 @@ install:
         docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/usr --regexp-library=none && ./waf build && ./waf install && ldconfig";
       elif [ "$DIST" == "ubuntu" ]; then
         docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/usr --regexp-library=none && ./waf build && ./waf install";
-      fi
+      fi;
     fi
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Install
 Requirements
 ------------
 
-* Python 2.6, 2.7, 3.3, 3.4 or 3.5.
+* Python 2.7, 3.3, 3.4 or 3.5.
 * `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed.
 
 Limitations


### PR DESCRIPTION
- Travis-ci for CentOS 6 does not work because of python version and I fixed it.
- Ubuntu 12.04 is not already officially supported and I want to deprecate it.