### PR TITLE
Implement some missing common methods

### DIFF
--- a/src/embedded_jubatus.pyx
+++ b/src/embedded_jubatus.pyx
@@ -95,16 +95,16 @@ cdef class _JubatusBase:
         raise RuntimeError
 
     def do_mix(self):
-        raise RuntimeError
+        return True
 
     def get_proxy_status(self):
         raise RuntimeError
 
     def get_name(self):
-        raise RuntimeError
+        return ''
 
     def set_name(self, new_name):
-        raise RuntimeError
+        raise RuntimeError('Unsupported')
 
     def get_client(self):
         raise RuntimeError


### PR DESCRIPTION
See. #31 

I tried to implement the followings:

* ``do_mix``: do nothing and always return `True`
* ``get_name``: always return empty string
* ``set_name``: raise exception with the message ``Unsupported``