### PR TITLE
Implement get_status

### DIFF
--- a/src/_wrapper.cpp
+++ b/src/_wrapper.cpp
@@ -113,6 +113,12 @@ bool _Classifier::delete_label(const std::string& target_label) {
     return handle->delete_label(target_label);
 }
 
+void _Classifier::get_status_(std::map<std::string, std::string>& status) const {
+    std::map<std::string, std::string> my_status;
+    handle->get_status(my_status);
+    status.insert(my_status.begin(), my_status.end());
+}
+
 _Regression::_Regression(const std::string& config) {
     using jubatus::core::driver::regression;
     using jubatus::core::regression::regression_factory;
@@ -133,6 +139,12 @@ void _Regression::train(double score, const datum& d) {
 
 double _Regression::estimate(const datum& d) {
     return handle->estimate(d);
+}
+
+void _Regression::get_status_(std::map<std::string, std::string>& status) const {
+    std::map<std::string, std::string> my_status;
+    handle->get_status(my_status);
+    status.insert(my_status.begin(), my_status.end());
 }
 
 _Recommender::_Recommender(const std::string& config) {
@@ -205,6 +217,10 @@ double _Recommender::calc_l2norm(const datum& d) {
     return handle->calc_l2norm(d);
 }
 
+void _Recommender::get_status_(std::map<std::string, std::string>& status) const {
+    // unimplemented
+}
+
 _NearestNeighbor::_NearestNeighbor(const std::string& config) {
     using jubatus::core::storage::column_table;
     using jubatus::core::driver::nearest_neighbor;
@@ -243,6 +259,12 @@ id_score_list_t _NearestNeighbor::similar_row_from_datum(const datum& d, size_t 
 
 std::vector<std::string> _NearestNeighbor::get_all_rows() {
     return handle->get_all_rows();
+}
+
+void _NearestNeighbor::get_status_(std::map<std::string, std::string>& status) const {
+    std::map<std::string, std::string> my_status;
+    status["data"] = lexical_cast<std::string>(handle->get_table()->dump_json());
+    status.insert(my_status.begin(), my_status.end());
 }
 
 _Anomaly::_Anomaly(const std::string& config) : idgen(0) {
@@ -290,6 +312,12 @@ double _Anomaly::calc_score(const datum& d) const {
 
 std::vector<std::string> _Anomaly::get_all_rows() const {
     return handle->get_all_rows();
+}
+
+void _Anomaly::get_status_(std::map<std::string, std::string>& status) const {
+    std::map<std::string, std::string> my_status;
+    handle->get_status(my_status);
+    status.insert(my_status.begin(), my_status.end());
 }
 
 _Clustering::_Clustering(const std::string& config) {
@@ -343,6 +371,10 @@ index_cluster_set _Clustering::get_core_members_light() const {
 
 index_cluster_unit _Clustering::get_nearest_members_light(const datum& d) const {
     return handle->get_nearest_members_light(d);
+}
+
+void _Clustering::get_status_(std::map<std::string, std::string>& status) const {
+    // unimplemented
 }
 
 _Burst::_Burst(const std::string& config) {
@@ -422,6 +454,10 @@ void _Burst::calculate_results() {
     handle->calculate_results();
 }
 
+void _Burst::get_status_(std::map<std::string, std::string>& status) const {
+    handle->get_status(status);
+}
+
 _Bandit::_Bandit(const std::string& config) {
     using jubatus::core::driver::bandit;
     std::string method;
@@ -459,6 +495,10 @@ std::map<std::string, jubatus::core::bandit::arm_info> _Bandit::get_arm_info(con
 
 bool _Bandit::reset(const std::string& player_id) {
     return handle->reset(player_id);
+}
+
+void _Bandit::get_status_(std::map<std::string, std::string>& status) const {
+    // unimplemented
 }
 
 struct stat_serv_config {
@@ -507,6 +547,10 @@ double _Stat::moment(const std::string& key, int degree, double center) const {
     return handle->moment(key, degree, center);
 }
 
+void _Stat::get_status_(std::map<std::string, std::string>& status) const {
+    status.insert(std::make_pair("storage", handle->get_model()->type()));
+}
+
 _Weight::_Weight(const std::string& config) {
     using jubatus::core::driver::weight;
     converter_config fvconv_config;
@@ -521,6 +565,10 @@ sfv_t _Weight::update(const datum& d) {
 
 sfv_t _Weight::calc_weight(const datum& d) const {
     return handle->calc_weight(d);
+}
+
+void _Weight::get_status_(std::map<std::string, std::string>& status) const {
+    handle->get_status(status);
 }
 
 struct graph_serv_config {
@@ -633,4 +681,10 @@ jubatus::core::graph::node_info _Graph::get_node(const std::string& node_id) con
 
 jubatus::core::graph::edge_info _Graph::get_edge(edge_id_t eid) const {
     return handle->get_edge(eid);
+}
+
+void _Graph::get_status_(std::map<std::string, std::string>& status) const {
+    std::map<std::string, std::string> my_status;
+    handle->get_model()->get_status(my_status);
+    status.insert(my_status.begin(), my_status.end());
 }

--- a/src/_wrapper.pxd
+++ b/src/_wrapper.pxd
@@ -6,6 +6,7 @@ from libcpp.pair cimport pair
 from libcpp.map cimport map
 
 ctypedef vector[pair[string, double]] sfv_t
+ctypedef map[string, map[string, string]] status_t
 ctypedef map[string, string] prop_t
 ctypedef uint64_t edge_id_t
 ctypedef uint64_t node_id_t
@@ -22,6 +23,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Regression:
         _Regression(const string& config) except +
@@ -31,6 +33,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Recommender:
         _Recommender(const string& config) except +
@@ -52,6 +55,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _NearestNeighbor:
         _NearestNeighbor(const string& config) except +
@@ -65,6 +69,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Anomaly:
         _Anomaly(const string& config) except +
@@ -80,6 +85,7 @@ cdef extern from '_wrapper.h' nogil:
         string get_config() except +
         void clear() except +
         string get_next_id() except +
+        status_t get_status() except +
 
     cdef cppclass _Clustering:
         _Clustering(const string& config) except +
@@ -95,6 +101,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Burst:
         cppclass Batch:
@@ -116,6 +123,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Bandit:
         _Bandit(const string& config) except +
@@ -129,6 +137,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Stat:
         _Stat(const string& config) except +
@@ -143,6 +152,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Weight:
         _Weight(const string& config) except +
@@ -152,6 +162,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
     cdef cppclass _Graph:
         _Graph(const string& config) except +
@@ -186,6 +197,7 @@ cdef extern from '_wrapper.h' nogil:
         void load(const string& data, const string& type, uint64_t ver) except +
         string get_config() except +
         void clear() except +
+        status_t get_status() except +
 
 cdef extern from 'jubatus/core/fv_converter/datum.hpp' namespace 'jubatus::core::fv_converter' nogil:
     cdef cppclass datum:

--- a/src/anomaly.pyx
+++ b/src/anomaly.pyx
@@ -65,6 +65,16 @@ cdef class Anomaly(_JubatusBase):
         cdef vector[string] ret = self._handle.get_all_rows()
         return [i.decode('ascii') for i in ret]
 
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }
+
     def fit(self, X):
         self.partial_fit(X)
 

--- a/src/bandit.pyx
+++ b/src/bandit.pyx
@@ -48,3 +48,13 @@ cdef class Bandit(_JubatusBase):
 
     def reset(self, player_id):
         return self._handle.reset(player_id.encode('utf8'))
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/burst.pyx
+++ b/src/burst.pyx
@@ -80,3 +80,13 @@ cdef class Burst(_JubatusBase):
 
     def remove_all_keywords(self):
         return self._handle.remove_all_keywords()
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/classifier.pyx
+++ b/src/classifier.pyx
@@ -87,6 +87,16 @@ cdef class Classifier(_JubatusBase):
     def delete_label(self, target_label):
         return self._handle.delete_label(target_label.encode('utf8'))
 
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }
+
     @property
     def classes_(self):
         return self._classes

--- a/src/clustering.pyx
+++ b/src/clustering.pyx
@@ -92,3 +92,13 @@ cdef class Clustering(_JubatusBase):
         for m in r:
             ret.append(WeightedIndex(m.first, m.second))
         return ret
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/embedded_jubatus.pyx
+++ b/src/embedded_jubatus.pyx
@@ -26,6 +26,7 @@ from _wrapper cimport keyword_params
 from _wrapper cimport keyword_with_params
 from _wrapper cimport lexical_cast
 from _wrapper cimport sfv_t
+from _wrapper cimport status_t
 from _wrapper cimport prop_t
 from _wrapper cimport node_id_t
 from _wrapper cimport edge_id_t
@@ -91,9 +92,6 @@ cdef class _JubatusBase:
             f.write(self.save_bytes())
         return {name: path}
 
-    def get_status(self):
-        raise RuntimeError
-
     def do_mix(self):
         return True
 
@@ -117,6 +115,7 @@ cdef class _JubatusBase:
         cfg, model = state
         self.__init__(json.loads(cfg))
         self.load_bytes(model)
+
 
 include 'types.pyx'
 include 'anomaly.pyx'

--- a/src/graph.pyx
+++ b/src/graph.pyx
@@ -125,3 +125,13 @@ cdef class Graph(_JubatusBase):
         e = self._handle.get_edge(edge_id)
         return Edge(props_native2py(e.p),
                     str(e.src), str(e.tgt))
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/nearest_neighbor.pyx
+++ b/src/nearest_neighbor.pyx
@@ -70,3 +70,13 @@ cdef class NearestNeighbor(_JubatusBase):
     def get_all_rows(self):
         cdef vector[string] ret = self._handle.get_all_rows()
         return [(<string>ret[i]).decode('utf8') for i in range(ret.size())]
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/recommender.pyx
+++ b/src/recommender.pyx
@@ -118,3 +118,13 @@ cdef class Recommender(_JubatusBase):
         cdef datum d
         datum_py2native(row, d)
         return self._handle.calc_l2norm(d)
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/regression.pyx
+++ b/src/regression.pyx
@@ -56,6 +56,16 @@ cdef class Regression(_JubatusBase):
         else:
             raise ValueError
 
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }
+
     def fit(self, X, y):
         self.clear()
         return self.partial_fit(X, y)

--- a/src/stat.pyx
+++ b/src/stat.pyx
@@ -46,3 +46,13 @@ cdef class Stat(_JubatusBase):
 
     def moment(self, key, degree, center):
         return self._handle.moment(key.encode('utf8'), degree, center)
+
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }

--- a/src/weight.pyx
+++ b/src/weight.pyx
@@ -39,6 +39,16 @@ cdef class Weight(_JubatusBase):
         r = self._handle.calc_weight(d)
         return _to_features(r)
 
+    def get_status(self):
+        cdef status_t status = self._handle.get_status()
+        return {
+            st.first.decode('utf8'): {
+                it.first.decode('utf8'): it.second.decode('utf8')
+                for it in st.second
+            }
+            for st in status
+        }
+
 cdef _to_features(sfv_t& r):
     cdef int sz
     sz = r.size()

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -71,7 +71,7 @@ class TestAnomaly(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))
 
     def test_add_bulk(self):

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -68,6 +68,12 @@ class TestAnomaly(unittest.TestCase):
         self.assertEqual(p.score, x.update(p.id, Datum({'x': 0.2})))
         self.assertEqual(p.score, x.overwrite(p.id, Datum({'x': 0.2})))
 
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))
+
     def test_add_bulk(self):
         x = Anomaly(CONFIG)
         data = [

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -68,5 +68,5 @@ class TestBandit(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -64,3 +64,9 @@ class TestBandit(unittest.TestCase):
         info = x.get_arm_info(player)
         self.assertEqual(3, len(info))
         self.assertTrue(isinstance(info[keys[0]], ArmInfo))
+
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -82,3 +82,9 @@ class TestBurst(unittest.TestCase):
         ret = x.get_result_at('balse', 41)
         self.assertTrue(isinstance(ret, Window))
         self.assertTrue(isinstance(ret.batches[0], Batch))
+
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -86,5 +86,5 @@ class TestBurst(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -81,6 +81,12 @@ class TestClassifier(unittest.TestCase):
             _test_classify(x)
             self.assertEqual(CONFIG, json.loads(x.get_config()))
 
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))
+
     def test_str(self):
         x = Classifier(CONFIG)
         self.assertEqual(2, x.train([

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -84,7 +84,7 @@ class TestClassifier(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))
 
     def test_str(self):

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -118,5 +118,5 @@ class TestClustering(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -114,3 +114,9 @@ class TestClustering(unittest.TestCase):
         self.assertEqual(CONFIG, json.loads(x.get_config()))
         self.assertEqual(1, x.get_revision())
         self.assertEqual(len(centers), len(x.get_k_center()))
+
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -63,3 +63,9 @@ class TestGraph(unittest.TestCase):
         self.assertEqual([n0, n1], g.get_shortest_path(
             ShortestPathQuery(n0, n1, 100, PresetQuery([], []))))
         self.assertEqual('4', g.create_node())
+
+        st = g.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -67,5 +67,5 @@ class TestGraph(unittest.TestCase):
         st = g.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -83,3 +83,9 @@ class TestNearestNeighbor(unittest.TestCase):
         self.assertEqual(
             set(['a0', 'a1', 'a2', 'a3', 'b0', 'b1', 'b2', 'b3']),
             set(x.get_all_rows()))
+
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -87,5 +87,5 @@ class TestNearestNeighbor(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -89,3 +89,9 @@ class TestRecommender(unittest.TestCase):
         x.load_bytes(model)
         self.assertTrue(x.get_all_rows())
         _valid_result(x.complete_row_from_id('4'))
+
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -93,5 +93,5 @@ class TestRecommender(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -71,7 +71,7 @@ class TestRegression(unittest.TestCase):
         st = x.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))
 
     def test_numpy(self):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -68,6 +68,12 @@ class TestRegression(unittest.TestCase):
             Datum({'x': 1.5}),
         ]))
 
+        st = x.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))
+
     def test_numpy(self):
         X = np.array([[1.0], [2.0], [4.0], [8.0], [16.0]])
         y = np.array([0.0, 1.0, 2.0, 3.0, 4.0])

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -53,3 +53,9 @@ class TestStat(unittest.TestCase):
         s.load_bytes(model)
         self.assertEqual(config, json.loads(s.get_config()))
         self.assertAlmostEqual(x_sum, s.sum('x'))
+
+        st = s.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -57,5 +57,5 @@ class TestStat(unittest.TestCase):
         st = s.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_weight.py
+++ b/tests/test_weight.py
@@ -56,3 +56,9 @@ class TestWeight(unittest.TestCase):
         self.assertEqual(CONFIG, json.loads(w.get_config()))
         r1 = dict([(x.key, x.value) for x in w.calc_weight(d)])
         self.assertEqual(r0, r1)
+
+        st = w.get_status()
+        self.assertTrue(isinstance(st, dict))
+        self.assertEqual(len(st), 1)
+        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertTrue(isinstance(st['embedded'], dict))

--- a/tests/test_weight.py
+++ b/tests/test_weight.py
@@ -60,5 +60,5 @@ class TestWeight(unittest.TestCase):
         st = w.get_status()
         self.assertTrue(isinstance(st, dict))
         self.assertEqual(len(st), 1)
-        self.assertEqual(st.keys()[0], 'embedded')
+        self.assertEqual(list(st.keys())[0], 'embedded')
         self.assertTrue(isinstance(st['embedded'], dict))


### PR DESCRIPTION
Refs. #53 

I Implemented ``get_status`` to support the same API as [Jubatus-Server](https://github.com/jubatus/jubatus/blob/1.1.1/jubatus/server/framework/server_helper.hpp#L134).

```js
{
    "embedded": {
        "master_num_group_frequencies": "0",
        "master_document_count": "0",
        "diff_num_document_frequencies": "0",
        "diff_document_count": "0",
        "diff_num_group_frequencies": "0",
        "diff_num_weights": "0",
        "storage": "local_storage",
        "num_features": "1",
        "master_num_group_total_lengths": "0",
        "pid": "13563",
        "diff_num_group_total_lengths": "0",
        "master_num_weights": "0",
        "clock_time": "1552895819",
        "master_num_document_frequencies": "0",
        "num_classes": "2",
        "weight_manager_version": "0"
    }
}
```

* The identifier of a instance is ``embedded``.
* Common attributes with Jubatus-Server are only ``pid`` and ``clock_time`` .