### PR TITLE
 Add a script to build manylinux2010 wheel package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ install:
       fi;
     fi
   - if [ "$DIST" == "centos" ] && [ $VERSION -eq 6 ]; then
-      docker exec test /usr/bin/scl enable python27 -- pip install --upgrade pip setuptools;
+      docker exec test /usr/bin/scl enable python27 -- pip install --upgrade pip setuptools cython;
     else
-      docker exec test pip install --upgrade pip setuptools;
+      docker exec test pip install --upgrade pip setuptools cython;
     fi
   - if [ "$TRAVIS_BRANCH" != "master" ]; then
       if [ "$DIST" == "centos" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ matrix:
     - env:
       - DIST=ubuntu
       - VERSION=16.04
+    - env:
+      - DIST=quay.io/pypa/manylinux2010_x86_64
+      - VERSION=latest
 
 before_install:
   - docker pull ${DIST}:${VERSION}
-  - docker run -w /root --name test -d ${DIST}:${VERSION} sleep infinity
-  - docker cp . test:/root/
+  - docker run -v $(pwd):/io -w /io --name test -d ${DIST}:${VERSION} sleep infinity
   - if [ "$DIST" == "centos" ]; then
       if [ $VERSION -eq 6 ]; then
         docker exec test rpm -Uvh http://download.jubat.us/yum/rhel/6/stable/x86_64/jubatus-release-6-2.el6.x86_64.rpm;
@@ -62,19 +64,17 @@ install:
     fi
   - if [ "$DIST" == "centos" ] && [ $VERSION -eq 6 ]; then
       docker exec test /usr/bin/scl enable python27 -- pip install --upgrade pip setuptools cython;
-    else
+    elif [ "$DIST" != "quay.io/pypa/manylinux2010_x86_64" ]; then
       docker exec test pip install --upgrade pip setuptools cython;
     fi
   - if [ "$TRAVIS_BRANCH" != "master" ]; then
       if [ "$DIST" == "centos" ]; then
         docker exec test yum -y install git bzip2 msgpack-devel-0.5.9;
-      elif [ "$DIST" == "ubuntu" ]; then
-        docker exec test apt-get --force-yes -y install git bzip2 libmsgpack-dev;
-      fi;
-      docker exec test git clone -b develop https://github.com/jubatus/jubatus_core.git;
-      if [ "$DIST" == "centos" ]; then
+        docker exec test git clone -b develop https://github.com/jubatus/jubatus_core.git;
         docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/usr --regexp-library=none && ./waf build && ./waf install && ldconfig";
       elif [ "$DIST" == "ubuntu" ]; then
+        docker exec test apt-get --force-yes -y install git bzip2 libmsgpack-dev;
+        docker exec test git clone -b develop https://github.com/jubatus/jubatus_core.git;
         docker exec test bash -ic "cd jubatus_core; ./waf configure --prefix=/usr --regexp-library=none && ./waf build && ./waf install";
       fi;
     fi
@@ -88,4 +88,6 @@ script:
       fi;
     elif [ "$DIST" == "ubuntu" ]; then
       docker exec -t test bash -ic "source /opt/jubatus/profile; pip install -e . && pip install scipy && python ./setup.py test";
+    elif [ "$DIST" == "quay.io/pypa/manylinux2010_x86_64" ]; then
+      docker exec -t test bash build-wheels.sh build_wheels;
     fi

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Install
 Requirements
 ------------
 
-* Python 2.7, 3.3, 3.4 or 3.5.
-* `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed.
+* Python 2.7, 3.3, 3.4, 3.5, 3.6 or 3.7.
+* `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed when build from sources.
 
 Limitations
 -----------

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,11 @@ Install
 Requirements
 ------------
 
-* Python 2.7, 3.3, 3.4, 3.5, 3.6 or 3.7.
-* `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed when build from sources.
+* Python 2.7, 3.5, 3.6 or 3.7
+* `Jubatus (Python Client) <https://pypi.org/project/jubatus/>`_ 1.0.2 or later
+* numpy 1.14-1.16 (1.17 or later don't support Python 2.7)
+* `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed when build from source package or repository
+* `Cython <https://pypi.org/project/Cython/>`_ needs to be installed when build from repository
 
 Limitations
 -----------

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,6 @@ Install
 
 ::
 
-  pip install Cython
   pip install embedded_jubatus
 
 Requirements

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e -x
+
+function build_wheels() {
+    if [ -z "${JUBATUS_VERSION}" ]; then
+        JUBATUS_VERSION=${TRAVIS_TAG:-master}
+    fi
+
+    rpm -Uvh http://download.jubat.us/yum/rhel/6/stable/x86_64/jubatus-release-6-2.el6.x86_64.rpm
+    yum install -y msgpack-devel oniguruma-devel
+
+    curl -OL https://github.com/jubatus/jubatus_core/archive/${JUBATUS_VERSION}.tar.gz
+    tar xf ${JUBATUS_VERSION}.tar.gz
+    cd jubatus_core-${JUBATUS_VERSION}
+    ./waf configure --prefix=/usr
+    ./waf build 
+    ./waf install
+    cd /io
+
+    for PYBIN in /opt/python/*m/bin; do
+        "${PYBIN}/pip" install cython
+        "${PYBIN}/pip" install -r /io/requirements.txt
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    done
+
+    for whl in wheelhouse/*.whl; do
+        auditwheel repair "$whl" --plat manylinux2010_x86_64 -w /io/wheelhouse/
+    done
+
+    /opt/python/cp37-cp37m/bin/python ./setup.py sdist
+
+    for PYBIN in /opt/python/*m/bin; do
+        V=${PYBIN%/bin}
+        V=${V#/opt/python/}
+        "${PYBIN}/pip" install /io/wheelhouse/embedded_jubatus-*-${V}-manylinux2010_x86_64.whl scipy
+        "${PYBIN}/python" ./setup.py test
+    done
+}
+
+if [ "$1" = "build_wheels" ]; then
+    build_wheels
+else
+    docker pull quay.io/pypa/manylinux2010_x86_64
+    docker run --rm \
+           -e JUBATUS_VERSION=${JUBATUS_VERSION} \
+           -e TRAVIS_TAG=${TRAVIS_TAG} \
+           -v $(pwd):/io \
+           quay.io/pypa/manylinux2010_x86_64 \
+           /io/build-wheels.sh build_wheels
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Cython>=0.27
 numpy>=1.14
 jubatus>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy>=1.14
+numpy>=1.14,<1.17.0  # numpy-1.17.0 dropped python2 supports
 jubatus>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,8 @@ def read(name):
 def _setup():
     include_dirs = []
     install_requires = read('requirements.txt').split('\n')
-    build_requires = [
-        line for line in install_requires
-        if line.startswith('numpy') or line.startswith('Cython')]
+    setup_requires = ['Cython'] + [
+        row for row in install_requires if row.startswith('numpy')]
 
     try:
         from Cython.Build import cythonize
@@ -51,24 +50,24 @@ def _setup():
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 3',
         ],
-        build_requires=build_requires,
+        setup_requires=setup_requires,
         install_requires=install_requires,
         test_suite='tests',
     )
+    kwargs['ext_modules'] = [Extension(
+        'embedded_jubatus', [
+            'src/embedded_jubatus.{}'.format(
+                'pyx' if cythonize else 'cpp'),
+            'src/_wrapper.cpp',
+            'src/_model.cpp'
+        ],
+        include_dirs=include_dirs,
+        libraries=['jubatus_core', 'jubatus_util_text'],
+        language='c++',
+        extra_compile_args=extra_compile_args)
+    ]
     if cythonize:
-        kwargs['ext_modules'] = cythonize([
-            Extension(
-                'embedded_jubatus',
-                [
-                    'src/embedded_jubatus.pyx',
-                    'src/_wrapper.cpp',
-                    'src/_model.cpp'
-                ],
-                include_dirs=include_dirs,
-                libraries=['jubatus_core', 'jubatus_util_text'],
-                language='c++',
-                extra_compile_args=extra_compile_args)
-        ])
+        kwargs['ext_modules'] = cythonize(kwargs['ext_modules'])
     setup(**kwargs)
 
 


### PR DESCRIPTION
In current version, embedded-jubatus installation is difficult on some linux distribution (Ubuntu etc).

This MR improves installation process.
* build from git repository source: still requires Cython, jubatus-core-devel, gcc
* build from sdist package: not requires Cython, still requires jubatus-core-devel, gcc
* pip install:  not requires cython, jubatus-core-devel, gcc