### PR TITLE
Fixed numpy version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,12 +82,12 @@ install:
 script:
   - if [ "$DIST" == "centos" ]; then
       if [ $VERSION -eq 6 ]; then
-        docker exec -t test /usr/bin/scl enable python27 -- bash -ic "pip install -e . && pip install scipy && python ./setup.py test";
+        docker exec -t test /usr/bin/scl enable python27 -- bash -ic "pip install -r requirements.txt && pip install -e . && pip install scipy && python ./setup.py test";
       else
-        docker exec -t test bash -ic "pip install -e . && pip install scipy && python ./setup.py test";
+        docker exec -t test bash -ic "pip install -r requirements.txt && pip install -e . && pip install scipy && python ./setup.py test";
       fi;
     elif [ "$DIST" == "ubuntu" ]; then
-      docker exec -t test bash -ic "source /opt/jubatus/profile; pip install -e . && pip install scipy && python ./setup.py test";
+      docker exec -t test bash -ic "source /opt/jubatus/profile; pip install -r requirements.txt && pip install -e . && pip install scipy && python ./setup.py test";
     elif [ "$DIST" == "quay.io/pypa/manylinux2010_x86_64" ]; then
       docker exec -t test bash build-wheels.sh build_wheels;
     fi

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -17,7 +17,7 @@ function build_wheels() {
     ./waf install
     cd /io
 
-    for PYBIN in /opt/python/*m/bin; do
+    for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install cython
         "${PYBIN}/pip" install -r /io/requirements.txt
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
@@ -29,11 +29,12 @@ function build_wheels() {
 
     /opt/python/cp37-cp37m/bin/python ./setup.py sdist
 
-    for PYBIN in /opt/python/*m/bin; do
+    cd /io/tests
+    for PYBIN in /opt/python/*/bin; do
         V=${PYBIN%/bin}
         V=${V#/opt/python/}
         "${PYBIN}/pip" install /io/wheelhouse/embedded_jubatus-*-${V}-manylinux2010_x86_64.whl scipy
-        "${PYBIN}/python" ./setup.py test
+        "${PYBIN}/python" -m unittest discover -v
     done
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy>=1.14,<1.17.0  # numpy-1.17.0 dropped python2 supports
+numpy>=1.16
 jubatus>=1.0.2


### PR DESCRIPTION
* There is no binary compatibility between numpy<1.16.0 and numpy>=1.16.0.
  manylinux2010 package not work on numpy<1.16.0 because build on numpy-1.16.
  Fixes lower version requirements.
* Removes upper version limits in requirements
  because no problems on python 2.7 if removed upper limits.